### PR TITLE
-criação classes modelo

### DIFF
--- a/market-manager/market-manager/Data/ApplicationDbContext.cs
+++ b/market-manager/market-manager/Data/ApplicationDbContext.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+﻿using market_manager.Models;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace market_manager.Data
@@ -9,5 +10,36 @@ namespace market_manager.Data
             : base(options)
         {
         }
+
+        public DbSet<Utilizadores> Utilizadores { get; set; }
+        public DbSet<Reservas> Reservas { get; set; }
+        public DbSet<Bancas> Bancas { get; set; }
+        public DbSet<Notificacoes> Notificacoes { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<Notificacoes>()
+                .HasOne(n => n.Destinatario)
+                .WithMany()
+                .HasForeignKey(n => n.DestinatarioId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<Notificacoes>()
+                .HasOne(n => n.Registo)
+                .WithMany()
+                .HasForeignKey(n => n.RegistoId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<Notificacoes>()
+                .HasOne(n => n.Reserva)
+                .WithMany(r => r.Notificacoes)
+                .HasForeignKey(n => n.ReservaId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+        }
+
+
     }
 }

--- a/market-manager/market-manager/Data/Migrations/20240331050530_market-manager.Designer.cs
+++ b/market-manager/market-manager/Data/Migrations/20240331050530_market-manager.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using market_manager.Data;
 
@@ -11,9 +12,11 @@ using market_manager.Data;
 namespace market_manager.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240331050530_market-manager")]
+    partial class marketmanager
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/market-manager/market-manager/Data/Migrations/20240331050530_market-manager.cs
+++ b/market-manager/market-manager/Data/Migrations/20240331050530_market-manager.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace market_manager.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class marketmanager : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Bancas",
+                columns: table => new
+                {
+                    BancaId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    NomeBanca = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CategoriaProdutos = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Largura = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    Comprimento = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    LocalizacaoX = table.Column<int>(type: "int", nullable: false),
+                    LocalizacaoY = table.Column<int>(type: "int", nullable: false),
+                    Estado = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Bancas", x => x.BancaId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Utilizadores",
+                columns: table => new
+                {
+                    UtilizadorId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    NomeUtilizador = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    PalavraPasse = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    TipoUtilizador = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    NomeCompleto = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Email = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Telefone = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Morada = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CodigoPostal = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Localidade = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Estado = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    NIF = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Utilizadores", x => x.UtilizadorId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Reservas",
+                columns: table => new
+                {
+                    ReservaId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UtilizadorId = table.Column<int>(type: "int", nullable: false),
+                    DataInicio = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DataFim = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DataCriacao = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Estado = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Reservas", x => x.ReservaId);
+                    table.ForeignKey(
+                        name: "FK_Reservas_Utilizadores_UtilizadorId",
+                        column: x => x.UtilizadorId,
+                        principalTable: "Utilizadores",
+                        principalColumn: "UtilizadorId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "BancasReservas",
+                columns: table => new
+                {
+                    BancasBancaId = table.Column<int>(type: "int", nullable: false),
+                    ReservasReservaId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BancasReservas", x => new { x.BancasBancaId, x.ReservasReservaId });
+                    table.ForeignKey(
+                        name: "FK_BancasReservas_Bancas_BancasBancaId",
+                        column: x => x.BancasBancaId,
+                        principalTable: "Bancas",
+                        principalColumn: "BancaId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_BancasReservas_Reservas_ReservasReservaId",
+                        column: x => x.ReservasReservaId,
+                        principalTable: "Reservas",
+                        principalColumn: "ReservaId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Notificacoes",
+                columns: table => new
+                {
+                    NotificacaoId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Tipo = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    DestinatarioId = table.Column<int>(type: "int", nullable: false),
+                    RegistoId = table.Column<int>(type: "int", nullable: false),
+                    DestinatarioTipo = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ReservaId = table.Column<int>(type: "int", nullable: true),
+                    Estado = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    DataCriacao = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UtilizadoresUtilizadorId = table.Column<int>(type: "int", nullable: true),
+                    UtilizadoresUtilizadorId1 = table.Column<int>(type: "int", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Notificacoes", x => x.NotificacaoId);
+                    table.ForeignKey(
+                        name: "FK_Notificacoes_Reservas_ReservaId",
+                        column: x => x.ReservaId,
+                        principalTable: "Reservas",
+                        principalColumn: "ReservaId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Notificacoes_Utilizadores_DestinatarioId",
+                        column: x => x.DestinatarioId,
+                        principalTable: "Utilizadores",
+                        principalColumn: "UtilizadorId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Notificacoes_Utilizadores_RegistoId",
+                        column: x => x.RegistoId,
+                        principalTable: "Utilizadores",
+                        principalColumn: "UtilizadorId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Notificacoes_Utilizadores_UtilizadoresUtilizadorId",
+                        column: x => x.UtilizadoresUtilizadorId,
+                        principalTable: "Utilizadores",
+                        principalColumn: "UtilizadorId");
+                    table.ForeignKey(
+                        name: "FK_Notificacoes_Utilizadores_UtilizadoresUtilizadorId1",
+                        column: x => x.UtilizadoresUtilizadorId1,
+                        principalTable: "Utilizadores",
+                        principalColumn: "UtilizadorId");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BancasReservas_ReservasReservaId",
+                table: "BancasReservas",
+                column: "ReservasReservaId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notificacoes_DestinatarioId",
+                table: "Notificacoes",
+                column: "DestinatarioId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notificacoes_RegistoId",
+                table: "Notificacoes",
+                column: "RegistoId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notificacoes_ReservaId",
+                table: "Notificacoes",
+                column: "ReservaId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notificacoes_UtilizadoresUtilizadorId",
+                table: "Notificacoes",
+                column: "UtilizadoresUtilizadorId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notificacoes_UtilizadoresUtilizadorId1",
+                table: "Notificacoes",
+                column: "UtilizadoresUtilizadorId1");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Reservas_UtilizadorId",
+                table: "Reservas",
+                column: "UtilizadorId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BancasReservas");
+
+            migrationBuilder.DropTable(
+                name: "Notificacoes");
+
+            migrationBuilder.DropTable(
+                name: "Bancas");
+
+            migrationBuilder.DropTable(
+                name: "Reservas");
+
+            migrationBuilder.DropTable(
+                name: "Utilizadores");
+        }
+    }
+}

--- a/market-manager/market-manager/Models/Bancas.cs
+++ b/market-manager/market-manager/Models/Bancas.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace market_manager.Models
+{
+    public class Bancas
+    {
+
+        [Key]
+        public int BancaId { get; set; }
+        public string NomeBanca { get; set; }
+        public string CategoriaProdutos { get; set; }
+        public decimal Largura { get; set; }
+        public decimal Comprimento { get; set; }
+        public int LocalizacaoX { get; set; }
+        public int LocalizacaoY { get; set; }
+        public string Estado { get; set; }
+
+        public ICollection<Reservas> Reservas { get; set; }
+
+    }
+}

--- a/market-manager/market-manager/Models/Notificacoes.cs
+++ b/market-manager/market-manager/Models/Notificacoes.cs
@@ -1,0 +1,31 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using System.ComponentModel.DataAnnotations;
+
+namespace market_manager.Models
+{
+    public class Notificacoes
+    {
+
+        [Key]
+        public int NotificacaoId { get; set; }
+        public string Tipo { get; set; }
+
+        [ForeignKey("Destinatario")]
+        public int DestinatarioId { get; set; }
+        public Utilizadores Destinatario { get; set; }
+
+        [ForeignKey("Registo")]
+        public int RegistoId { get; set; }
+        public Utilizadores Registo { get; set; }
+
+        public string DestinatarioTipo { get; set; }
+
+        [ForeignKey("Reserva")]
+        public int? ReservaId { get; set; }
+        public Reservas Reserva { get; set; }
+
+        public string Estado { get; set; }
+        public DateTime DataCriacao { get; set; }
+
+    }
+}

--- a/market-manager/market-manager/Models/Reservas.cs
+++ b/market-manager/market-manager/Models/Reservas.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using System.ComponentModel.DataAnnotations;
+
+namespace market_manager.Models
+{
+    public class Reservas
+    {
+
+        [Key]
+        public int ReservaId { get; set; }
+
+        [ForeignKey("Utilizador")]
+        public int UtilizadorId { get; set; }
+        public Utilizadores Utilizador { get; set; }
+
+        public DateTime DataInicio { get; set; }
+        public DateTime DataFim { get; set; }
+        public DateTime DataCriacao { get; set; }
+        public string Estado { get; set; }
+
+        public ICollection<Bancas> Bancas { get; set; }
+        public ICollection<Notificacoes> Notificacoes { get; set; }
+
+    }
+}

--- a/market-manager/market-manager/Models/Utilizadores.cs
+++ b/market-manager/market-manager/Models/Utilizadores.cs
@@ -1,0 +1,27 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace market_manager.Models
+{
+    public class Utilizadores
+    {
+
+        [Key]
+        public int UtilizadorId { get; set; }
+        public string NomeUtilizador { get; set; }
+        public string PalavraPasse { get; set; }
+        public string TipoUtilizador { get; set; }
+        public string NomeCompleto { get; set; }
+        public string Email { get; set; }
+        public string Telefone { get; set; }
+        public string Morada { get; set; }
+        public string CodigoPostal { get; set; }
+        public string Localidade { get; set; }
+        public string Estado { get; set; }
+        public string NIF { get; set; }
+
+        public ICollection<Reservas> Reservas { get; set; }
+        public ICollection<Notificacoes> NotificacoesRecebidas { get; set; }
+        public ICollection<Notificacoes> NotificacaoesEnviadas { get; set; }
+
+    }
+}

--- a/market-manager/market-manager/appsettings.json
+++ b/market-manager/market-manager/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-market_manager-5ea0c8d8-b4ed-4056-89f4-19193c14b639;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=Server=(localdb)\\mssqllocaldb;Database=market-manager;Trusted_Connection=True;MultipleActiveResultSets=true;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Foi criada a primeira migração da base de dados com os relacionamentos feitos, os relacionamentos de notificações foram feitos com fluent api ao modificar a função OnModelCreating do contexto da base de dados.

Foram retornados os seguintes erros na migração da bd que vao ser resolvidos em migrações novas:

`There are multiple relationships between 'Notificacoes' and 'Utilizadores' without configured foreign key properties. This will cause Entity Framework to create shadow properties on 'Notificacoes' with names dependent on the discovery order. Consider configuring the foreign key properties using the [ForeignKey] attribute or in 'OnModelCreating'.
Microsoft.EntityFrameworkCore.Model.Validation[10625]
      The foreign key property 'Notificacoes.UtilizadoresUtilizadorId1' was created in shadow state because a conflicting property with the simple name 'UtilizadoresUtilizadorId' exists in the entity type, but is either not mapped, is already used for another relationship, or is incompatible with the associated primary key type. See https://aka.ms/efcore-relationships for information on mapping relationships in EF Core.
Microsoft.EntityFrameworkCore.Model.Validation[30000]
      No store type was specified for the decimal property 'Comprimento' on entity type 'Bancas'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values in 'OnModelCreating' using 'HasColumnType', specify precision and scale using 'HasPrecision', or configure a value converter using 'HasConversion'.
Microsoft.EntityFrameworkCore.Model.Validation[30000]
      No store type was specified for the decimal property 'Largura' on entity type 'Bancas'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values in 'OnModelCreating' using 'HasColumnType', specify precision and scale using 'HasPrecision', or configure a value converter using 'HasConversion'.
Microsoft.EntityFrameworkCore.Model[10605]
      There are multiple relationships between 'Notificacoes' and 'Utilizadores' without configured foreign key properties. This will cause Entity Framework to create shadow properties on 'Notificacoes' with names dependent on the discovery order. Consider configuring the foreign key properties using the [ForeignKey] attribute or in 'OnModelCreating'.
There are multiple relationships between 'Notificacoes' and 'Utilizadores' without configured foreign key properties. This will cause Entity Framework to create shadow properties on 'Notificacoes' with names dependent on the discovery order. Consider configuring the foreign key properties using the [ForeignKey] attribute or in 'OnModelCreating'.
Microsoft.EntityFrameworkCore.Model.Validation[10625]
      The foreign key property 'Notificacoes.UtilizadoresUtilizadorId1' was created in shadow state because a conflicting property with the simple name 'UtilizadoresUtilizadorId' exists in the entity type, but is either not mapped, is already used for another relationship, or is incompatible with the associated primary key type. See https://aka.ms/efcore-relationships for information on mapping relationships in EF Core.
The foreign key property 'Notificacoes.UtilizadoresUtilizadorId1' was created in shadow state because a conflicting property with the simple name 'UtilizadoresUtilizadorId' exists in the entity type, but is either not mapped, is already used for another relationship, or is incompatible with the associated primary key type. See https://aka.ms/efcore-relationships for information on mapping relationships in EF Core.
Microsoft.EntityFrameworkCore.Model.Validation[30000]
      No store type was specified for the decimal property 'Comprimento' on entity type 'Bancas'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values in 'OnModelCreating' using 'HasColumnType', specify precision and scale using 'HasPrecision', or configure a value converter using 'HasConversion'.
No store type was specified for the decimal property 'Comprimento' on entity type 'Bancas'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values in 'OnModelCreating' using 'HasColumnType', specify precision and scale using 'HasPrecision', or configure a value converter using 'HasConversion'.
Microsoft.EntityFrameworkCore.Model.Validation[30000]
      No store type was specified for the decimal property 'Largura' on entity type 'Bancas'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values in 'OnModelCreating' using 'HasColumnType', specify precision and scale using 'HasPrecision', or configure a value converter using 'HasConversion'.
No store type was specified for the decimal property 'Largura' on entity type 'Bancas'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values in 'OnModelCreating' using 'HasColumnType', specify precision and scale using 'HasPrecision', or configure a value converter using 'HasConversion'.
To undo this action, use Remove-Migration.
PM> update-database
Build started...
Build succeeded.
Microsoft.EntityFrameworkCore.Model[10605]
      There are multiple relationships between 'Notificacoes' and 'Utilizadores' without configured foreign key properties. This will cause Entity Framework to create shadow properties on 'Notificacoes' with names dependent on the discovery order. Consider configuring the foreign key properties using the [ForeignKey] attribute or in 'OnModelCreating'.
Microsoft.EntityFrameworkCore.Model.Validation[10625]
      The foreign key property 'Notificacoes.UtilizadoresUtilizadorId1' was created in shadow state because a conflicting property with the simple name 'UtilizadoresUtilizadorId' exists in the entity type, but is either not mapped, is already used for another relationship, or is incompatible with the associated primary key type. See https://aka.ms/efcore-relationships for information on mapping relationships in EF Core.
Microsoft.EntityFrameworkCore.Model.Validation[30000]
      No store type was specified for the decimal property 'Comprimento' on entity type 'Bancas'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values in 'OnModelCreating' using 'HasColumnType', specify precision and scale using 'HasPrecision', or configure a value converter using 'HasConversion'.
Microsoft.EntityFrameworkCore.Model.Validation[30000]
      No store type was specified for the decimal property 'Largura' on entity type 'Bancas'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values in 'OnModelCreating' using 'HasColumnType', specify precision and scale using 'HasPrecision', or configure a value converter using 'HasConversion'.`